### PR TITLE
AE-1845: Update URL for CQC API

### DIFF
--- a/tap_cqc_org_uk/client.py
+++ b/tap_cqc_org_uk/client.py
@@ -64,6 +64,7 @@ class cqc_org_ukStream(RESTStream):
             request.headers["User-Agent"] = self.config["partner_code"]
 
             # Replace the encoded colon in the URL with a regular colon (the API doesn't like the encoded version)
+            # TODO: Apply urlencode python function in get_url_params method in streams instead. But, we will need to upgrade SDK version
             request.url = request.url.replace("%3A", ":")
 
             return request


### PR DESCRIPTION
Changes: -
- Updates URL for CQC API
- Adds `User-Agent` string to headers
- Replaces encoded `:` characters in request URL timestamp parameters