### PR TITLE
AE-2950: Fix backoff for failed requests

### DIFF
--- a/tap_cqc_org_uk/client.py
+++ b/tap_cqc_org_uk/client.py
@@ -108,8 +108,8 @@ class cqc_org_ukStream(RESTStream):
                 RetriableAPIError,
                 requests.exceptions.ReadTimeout,
             ),
-            max_tries=16,
-            factor=10,
+            max_tries=6,
+            factor=2,
         )(func)
         return decorator
 


### PR DESCRIPTION
Currently the backoff setting will wait for 7 days if a API request consistently fails! This PR fixes this.